### PR TITLE
#8: Properly reinitialize the service worker when waking up

### DIFF
--- a/extension/IconSwitcher.js
+++ b/extension/IconSwitcher.js
@@ -22,13 +22,13 @@ class IconSwitcher {
     this.#options = options;
     this.#logger = logger;
     this.#systemColorScheme = "unset";
-    this.#getSystemColorScheme();
   }
 
   /**
    * @returns {Promise<void>}
    */
   async start() {
+    await this.#getSystemColorScheme();
     if (!(await this.#chrome.offscreen.hasDocument())) {
       this.#logger.log("Creating offscreen document");
       await this.#chrome.offscreen.createDocument({
@@ -36,6 +36,7 @@ class IconSwitcher {
         reasons: ["MATCH_MEDIA"],
         justification: "Detect system color scheme",
       });
+      this.#logger.log("Offscreen document created");
     }
   }
 

--- a/extension/NotificationsExpert.js
+++ b/extension/NotificationsExpert.js
@@ -1,6 +1,6 @@
 class NotificationsExpert {
   static get CURRENT_VERSION() {
-    return 30100;
+    return 30101;
   }
   #chrome;
 
@@ -11,7 +11,7 @@ class NotificationsExpert {
     this.#chrome = chromeInstance;
   }
 
-  async start() {
+  start() {
     // Run after 3 seconds to allow the extension to load
     setTimeout(() => {
       this.#run();

--- a/extension/TabTracker.js
+++ b/extension/TabTracker.js
@@ -32,9 +32,16 @@ class TabTracker {
       return;
     }
 
-    const tabState = await this.#chrome.storage.session.get({
-      tabState: {},
-    });
+    const tabState = (
+      await this.#chrome.storage.session.get({
+        tabState: {},
+      })
+    ).tabState;
+    if (Object.keys(tabState).length > 0) {
+      this.#logger.log("Tab state already initialized, skipping...");
+      return;
+    }
+
     // Populate the tabState map with current tab information
     for (const tab of tabs) {
       if (tab.id && tab.url) {

--- a/extension/UpgradeCoordinator.js
+++ b/extension/UpgradeCoordinator.js
@@ -16,6 +16,7 @@ class UpgradeCoordinator {
    * @returns {Promise<void>}
    */
   async upgrade() {
+    this.#logger.log("Starting upgrade process");
     const keys = await this.#chrome.storage.sync.getKeys();
 
     // We don't want to use the terms "whitelist" and "blacklist" anymore.
@@ -23,6 +24,10 @@ class UpgradeCoordinator {
     // make sense to store the two lists separately. We should store a single
     // list and a flag indicating whether it's an allowlist or a blocklist.
     if (keys.includes("usingWhitelist")) {
+      this.#logger.log(
+        "Upgrading from whitelist/blacklist to allowlist/blocklist"
+      );
+
       const usingAllowList = await this.#chrome.storage.sync.get(
         "usingWhitelist"
       );
@@ -41,6 +46,8 @@ class UpgradeCoordinator {
         allowOrBlockList: list,
         usingAllowList,
       });
+    } else {
+      this.#logger.log("No upgrade needed, already using allowlist/blocklist");
     }
   }
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "AutoMute",
   "description": "Automatically mutes each new tab the instant it is opened.",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "permissions": ["tabs", "storage", "notifications", "offscreen"],
   "background": {
     "service_worker": "service_worker.js",

--- a/extension/service_worker.js
+++ b/extension/service_worker.js
@@ -7,41 +7,41 @@ import AutoMuteExtension from "./AutoMuteExtension.js";
 import UpgradeCoordinator from "./UpgradeCoordinator.js";
 import IconSwitcher from "./IconSwitcher.js";
 
+let extension;
+
 (function (_chrome, _console) {
-  new UpgradeCoordinator(_chrome).upgrade().then(() => {
-    const extensionOptions = new ExtensionOptions(_chrome);
-    const urlMatcher = new UrlMatcher(_console);
-    const listExpert = new ListExpert(extensionOptions, urlMatcher);
+  const upgradeCoordinator = new UpgradeCoordinator(_chrome, _console);
+  const extensionOptions = new ExtensionOptions(_chrome);
+  const urlMatcher = new UrlMatcher(_console);
+  const listExpert = new ListExpert(extensionOptions, urlMatcher);
 
-    const tabTracker = new TabTracker(
-      _chrome,
-      extensionOptions,
-      listExpert,
-      _console
-    );
+  const tabTracker = new TabTracker(
+    _chrome,
+    extensionOptions,
+    listExpert,
+    _console
+  );
 
-    tabTracker.start().then(() => {
-      const iconSwitcher = new IconSwitcher(
-        _chrome,
-        tabTracker,
-        extensionOptions,
-        _console
-      );
+  const iconSwitcher = new IconSwitcher(
+    _chrome,
+    tabTracker,
+    extensionOptions,
+    _console
+  );
 
-      const extension = new AutoMuteExtension(
-        _chrome,
-        extensionOptions,
-        tabTracker,
-        iconSwitcher,
-        _console
-      );
+  extension = new AutoMuteExtension(
+    _chrome,
+    upgradeCoordinator,
+    extensionOptions,
+    tabTracker,
+    iconSwitcher,
+    _console
+  );
 
-      extension.start().then(async () => {
-        await iconSwitcher.start();
+  extension.start();
 
-        const notificationsExpert = new NotificationsExpert(_chrome);
-        notificationsExpert.start();
-      });
-    });
-  });
+  const notificationsExpert = new NotificationsExpert(_chrome);
+  notificationsExpert.start();
 })(self.chrome, self.console);
+
+export { extension };

--- a/tests/UpgradeCoordinator.test.js
+++ b/tests/UpgradeCoordinator.test.js
@@ -43,7 +43,9 @@ describe("upgrade()", () => {
         },
       },
     };
-    const logger = jest.fn();
+    const logger = {
+      log: jest.fn(),
+    };
     const upgradeCoordinator = new UpgradeCoordinator(chrome, logger);
 
     await upgradeCoordinator.upgrade();
@@ -94,7 +96,9 @@ google.com",
         },
       },
     };
-    const logger = jest.fn();
+    const logger = {
+      log: jest.fn(),
+    };
     const upgradeCoordinator = new UpgradeCoordinator(chrome, logger);
 
     await upgradeCoordinator.upgrade();

--- a/tests/jest.config.json
+++ b/tests/jest.config.json
@@ -1,4 +1,0 @@
-{
-  "clearMocks": true,
-  "testEnvironment": "jsdom"
-}


### PR DESCRIPTION
This consists of two main fixes:

1. Listeners are always added synchronously, as is recommended by Google.
2. Don't redo the `muteAllTabsByApplicationLogic()` call if the service worker is being awakened by an event (not initial load).